### PR TITLE
Rebrand PollFlex to FlexPoll across all files

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>PollFlex — The Place to Put a Poll</title>
+    <title>FlexPoll — The Place to Put a Poll</title>
     <meta name="description" content="Create and share polls easily. Standard, Schedule, Location, Ranking, Priority, and Custom poll types." />
     <link rel="canonical" href="https://0815poll.vercel.app/" />
     <meta name="robots" content="index, follow" />
@@ -14,26 +14,26 @@
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-    <meta name="apple-mobile-web-app-title" content="PollFlex" />
+    <meta name="apple-mobile-web-app-title" content="FlexPoll" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="PollFlex" />
-    <meta property="og:title" content="PollFlex — The Place to Put a Poll" />
+    <meta property="og:site_name" content="FlexPoll" />
+    <meta property="og:title" content="FlexPoll — The Place to Put a Poll" />
     <meta property="og:description" content="Create and share polls easily. Standard, Schedule, Location, Ranking, Priority, and Custom poll types." />
     <meta property="og:url" content="https://0815poll.vercel.app/" />
     <meta property="og:image" content="https://0815poll.vercel.app/og-image.svg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:alt" content="PollFlex — Create and share every kind of poll" />
+    <meta property="og:image:alt" content="FlexPoll — Create and share every kind of poll" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="PollFlex — The Place to Put a Poll" />
+    <meta name="twitter:title" content="FlexPoll — The Place to Put a Poll" />
     <meta name="twitter:description" content="Create and share polls easily. Standard, Schedule, Location, Ranking, Priority, and Custom poll types." />
     <meta name="twitter:image" content="https://0815poll.vercel.app/og-image.png" />
-    <meta name="twitter:image:alt" content="PollFlex — Create and share every kind of poll" />
+    <meta name="twitter:image:alt" content="FlexPoll — Create and share every kind of poll" />
 
     <!-- Prevent dark-mode flash: apply class before React mounts -->
     <script>(function(){try{var t=localStorage.getItem('theme');if(t==='dark'||(t!=='light'&&window.matchMedia('(prefers-color-scheme:dark)').matches)){document.documentElement.classList.add('dark')}}catch(e){}})();</script>
@@ -49,7 +49,7 @@
     {
       "@context": "https://schema.org",
       "@type": "WebApplication",
-      "name": "PollFlex",
+      "name": "FlexPoll",
       "url": "https://0815poll.vercel.app",
       "description": "Create and share polls easily. Standard, Schedule, Location, Ranking, Priority, and Custom poll types.",
       "applicationCategory": "SocialApplication",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "pollflex",
+  "name": "flexpoll",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pollflex",
+      "name": "flexpoll",
       "version": "0.1.0",
       "dependencies": {
         "@emailjs/browser": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pollflex",
+  "name": "flexpoll",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -48,8 +48,8 @@
     <text x="0" y="400" font-family="system-ui, -apple-system, sans-serif" font-size="22" fill="#94a3b8">Standard · Location · Schedule · Ranking · Sandbox</text>
 
     <!-- App name -->
-    <text x="0" y="492" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="700" fill="#ffffff">PollFlex</text>
-    <text x="0" y="524" font-family="system-ui, -apple-system, sans-serif" font-size="16" fill="#64748b">pollflex.vercel.app</text>
+    <text x="0" y="492" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="700" fill="#ffffff">FlexPoll</text>
+    <text x="0" y="524" font-family="system-ui, -apple-system, sans-serif" font-size="16" fill="#64748b">flexpoll.vercel.app</text>
   </g>
 
   <!-- Right: poll card mockup -->

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -40,7 +40,7 @@ export default function InstallPrompt() {
   return (
     <div className="fixed bottom-20 left-4 right-4 z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg p-4 flex items-center gap-3 md:left-auto md:right-6 md:w-80">
       <div className="flex-1">
-        <p className="text-sm font-semibold text-gray-900 dark:text-white">Install PollFlex</p>
+        <p className="text-sm font-semibold text-gray-900 dark:text-white">Install FlexPoll</p>
         <p className="text-xs text-gray-500 dark:text-gray-400">Add to your home screen for quick access</p>
       </div>
       <button

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -22,7 +22,7 @@ export default function Sidebar() {
         <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary-500">
           <BarChart2 className="h-5 w-5 text-white" />
         </div>
-        <span className="text-lg font-bold text-gray-900 dark:text-white">PollFlex</span>
+        <span className="text-lg font-bold text-gray-900 dark:text-white">FlexPoll</span>
       </div>
 
       {/* Navigation */}

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -95,7 +95,7 @@ export default function Auth() {
           <div className="mx-auto mb-3 flex h-16 w-16 items-center justify-center rounded-2xl bg-primary-500 shadow-lg">
             <BarChart2 className="h-8 w-8 text-white" />
           </div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">PollFlex</h1>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">FlexPoll</h1>
           <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">The place to put a poll</p>
         </div>
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -51,7 +51,7 @@ export default function Home() {
 
   const greeting = user
     ? `Hello, ${userProfile?.displayName || user.displayName || 'there'}!`
-    : 'Welcome to PollFlex'
+    : 'Welcome to FlexPoll'
 
   return (
     <Layout>

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -232,7 +232,7 @@ export default function LandingPage() {
       <header className="sticky top-0 z-50 bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-800">
         <div className="mx-auto max-w-6xl px-6 flex h-14 items-center justify-between">
           <div className="flex items-center gap-8">
-            <span className="text-lg font-bold text-gray-900 dark:text-white">PollFlex</span>
+            <span className="text-lg font-bold text-gray-900 dark:text-white">FlexPoll</span>
             <nav className="hidden md:flex items-center gap-6">
               <a href="#poll-types" className="text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Poll Types</a>
               <a href="#custom-editor" className="text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Custom Editor</a>
@@ -329,7 +329,7 @@ export default function LandingPage() {
               <span className="text-xs font-semibold text-gray-500 dark:text-gray-400">7 Poll Types</span>
             </div>
             <h2 className="text-3xl font-extrabold text-gray-900 dark:text-white md:text-4xl">The right format for every question</h2>
-            <p className="mt-3 text-gray-500 dark:text-gray-400 text-base max-w-xl mx-auto">Don't force your question into the wrong format. PollFlex has a dedicated poll type for every situation — all included, all free.</p>
+            <p className="mt-3 text-gray-500 dark:text-gray-400 text-base max-w-xl mx-auto">Don't force your question into the wrong format. FlexPoll has a dedicated poll type for every situation — all included, all free.</p>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
             {POLL_TYPES.map(({ label, description, icon: Icon, bg, iconColor }) => (
@@ -419,7 +419,7 @@ export default function LandingPage() {
                 Free forever.<br />Open source always.
               </h2>
               <p className="mt-4 text-white/60 leading-relaxed">
-                PollFlex is completely free — no hidden fees, no premium tiers, no paywalls. The entire codebase is open source. Inspect it, fork it, self-host it, or contribute back.
+                FlexPoll is completely free — no hidden fees, no premium tiers, no paywalls. The entire codebase is open source. Inspect it, fork it, self-host it, or contribute back.
               </p>
               <div className="mt-8 flex flex-wrap gap-3">
                 <a
@@ -510,7 +510,7 @@ export default function LandingPage() {
         <div className="mx-auto max-w-6xl px-6 flex flex-col sm:flex-row items-center justify-between gap-4">
           <div className="flex items-center gap-3">
             <div>
-              <span className="text-sm font-bold text-gray-900 dark:text-white">PollFlex</span>
+              <span className="text-sm font-bold text-gray-900 dark:text-white">FlexPoll</span>
               <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">© 2026 Designed &amp; Made by Johannes Gnadlinger</p>
             </div>
             <a

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,8 +11,8 @@ export default defineConfig({
       injectRegister: 'script-defer',
       includeAssets: ['favicon.svg', 'favicon.ico', 'apple-touch-icon-180x180.png', 'robots.txt'],
       manifest: {
-        name: 'PollFlex — The Place to Put a Poll',
-        short_name: 'PollFlex',
+        name: 'FlexPoll — The Place to Put a Poll',
+        short_name: 'FlexPoll',
         description: 'Create and share polls easily. Standard, Schedule, Location, Ranking, Priority, and Custom poll types.',
         start_url: '/',
         display: 'standalone',


### PR DESCRIPTION
## Summary
This PR updates the application branding from "PollFlex" to "FlexPoll" throughout the codebase, including HTML metadata, React components, configuration files, and assets.

## Key Changes
- **HTML metadata** (`index.html`): Updated page title, Open Graph tags, Twitter Card metadata, and JSON-LD schema to use "FlexPoll"
- **Apple/PWA metadata**: Changed apple-mobile-web-app-title and manifest configuration to reflect new branding
- **React components**: Updated brand name in:
  - `LandingPage.tsx` (header, hero section, and footer)
  - `Sidebar.tsx` (logo text)
  - `Auth.tsx` (authentication page heading)
  - `Home.tsx` (welcome greeting)
  - `InstallPrompt.tsx` (installation prompt text)
- **Configuration files**: Updated `vite.config.ts` manifest and `package.json` name field
- **Assets**: Updated `public/og-image.svg` with new branding and URL reference

## Implementation Details
- All instances of "PollFlex" have been consistently replaced with "FlexPoll"
- URL references updated from `pollflex.vercel.app` to `flexpoll.vercel.app` in OG image
- Package name updated from "pollflex" to "flexpoll" for consistency
- Changes maintain all existing functionality while updating visual branding across user-facing and configuration surfaces

https://claude.ai/code/session_01SMK9GKoDkhkSY5Jf8kErpg