### PR TITLE
Fix notification "Mark all read" button wrapping on mobile

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -82,7 +82,7 @@ export default function Layout({
                     )}
                   </button>
                 )}
-                {headerRight && <div className="w-10 flex justify-end lg:w-auto">{headerRight}</div>}
+                {headerRight && <div className="flex justify-end whitespace-nowrap">{headerRight}</div>}
               </div>
             </header>
           )}


### PR DESCRIPTION
## Summary
- The `headerRight` container in Layout.tsx had a fixed `w-10` (40px) width on mobile, causing each word in "Mark all read" to stack vertically on its own line
- Replaced `w-10` with `whitespace-nowrap` so the button text stays on a single line regardless of screen size

## Test plan
- [ ] Open the notifications page on a mobile device or narrow viewport
- [ ] Verify "Mark all read" button displays on a single line
- [ ] Verify header layout still looks correct on desktop

https://claude.ai/code/session_01E69FFVMVZdwAFMds35PBvw