### PR TITLE
Fix sitemap.xml returning 404 by adding explicit pass-through rewrite in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -39,6 +39,7 @@
   ],
   "rewrites": [
     { "source": "/api/(.*)", "destination": "/api/$1" },
+    { "source": "/sitemap.xml", "destination": "/sitemap.xml" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
The catch-all rewrite rule was intercepting /sitemap.xml before Vercel could serve the static file.

https://claude.ai/code/session_01BmXmuVRy424D3CnWnnvoMZ