### PR TITLE
feat: add custom SSR pre-render pipeline for landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>FlexPoll — The Place to Put a Poll</title>
-    <meta name="description" content="Create and share polls easily. Standard, Schedule, Location, Ranking, Priority, and Custom poll types." />
-    <link rel="canonical" href="https://0815poll.vercel.app/" />
-    <meta name="robots" content="index, follow" />
+    <!-- Page title, description, canonical, OG, Twitter, JSON-LD injected by react-helmet-async per route -->
     <meta name="theme-color" content="#5d5fef" />
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
     <link rel="icon" href="/favicon.svg" sizes="any" type="image/svg+xml" />
@@ -16,25 +13,6 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="FlexPoll" />
 
-    <!-- Open Graph -->
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="FlexPoll" />
-    <meta property="og:title" content="FlexPoll — The Place to Put a Poll" />
-    <meta property="og:description" content="Create and share polls easily. Standard, Schedule, Location, Ranking, Priority, and Custom poll types." />
-    <meta property="og:url" content="https://0815poll.vercel.app/" />
-    <meta property="og:image" content="https://0815poll.vercel.app/og-image.svg" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
-    <meta property="og:image:type" content="image/svg+xml" />
-    <meta property="og:image:alt" content="FlexPoll — Create and share every kind of poll" />
-
-    <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="FlexPoll — The Place to Put a Poll" />
-    <meta name="twitter:description" content="Create and share polls easily. Standard, Schedule, Location, Ranking, Priority, and Custom poll types." />
-    <meta name="twitter:image" content="https://0815poll.vercel.app/og-image.png" />
-    <meta name="twitter:image:alt" content="FlexPoll — Create and share every kind of poll" />
-
     <!-- Prevent dark-mode flash: apply class before React mounts -->
     <script>(function(){try{var t=localStorage.getItem('theme');if(t==='dark'||(t!=='light'&&window.matchMedia('(prefers-color-scheme:dark)').matches)){document.documentElement.classList.add('dark')}}catch(e){}})();</script>
 
@@ -43,26 +21,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" media="print" onload="this.media='all'" />
-
-    <!-- Structured Data -->
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebApplication",
-      "name": "FlexPoll",
-      "url": "https://0815poll.vercel.app",
-      "description": "Create and share polls easily. Standard, Schedule, Location, Ranking, Priority, and Custom poll types.",
-      "applicationCategory": "SocialApplication",
-      "operatingSystem": "Web",
-      "browserRequirements": "Requires JavaScript",
-      "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "USD"
-      },
-      "inLanguage": "en"
-    }
-    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-helmet-async": "^3.0.0",
         "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.4.0"
       },
@@ -7948,9 +7949,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8043,6 +8044,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/is-array-buffer": {
@@ -8568,7 +8578,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -8796,6 +8805,18 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -9926,6 +9947,26 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-3.0.0.tgz",
+      "integrity": "sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
@@ -10427,6 +10468,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.33.5",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && vite build --ssr src/entry-server.tsx --outDir dist-ssr && node scripts/prerender.js",
     "lint": "eslint .",
     "preview": "vite preview"
   },
@@ -23,6 +23,7 @@
     "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-helmet-async": "^3.0.0",
     "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.4.0"
   },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://0815poll.vercel.app/sitemap.xml
+Sitemap: https://flexpoll.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://0815poll.vercel.app/</loc>
-    <lastmod>2026-03-22</lastmod>
+    <loc>https://flexpoll.app/</loc>
+    <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://0815poll.vercel.app/explore</loc>
-    <lastmod>2026-03-22</lastmod>
+    <loc>https://flexpoll.app/explore</loc>
+    <lastmod>2026-06-18</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://0815poll.vercel.app/create</loc>
-    <lastmod>2026-03-22</lastmod>
+    <loc>https://flexpoll.app/create</loc>
+    <lastmod>2026-06-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -1,0 +1,32 @@
+import { readFileSync, writeFileSync, rmSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const distDir = resolve(import.meta.dirname, '../dist')
+const ssrDir = resolve(import.meta.dirname, '../dist-ssr')
+
+const { render } = await import(resolve(ssrDir, 'entry-server.js'))
+const { appHtml } = render('/')
+
+// react-helmet-async v3 SSR: hoists title/meta/link before the first <div,
+// and renders <script> tags inline within the component tree.
+// We split at the first <div to separate head tags from body content.
+const firstDivIdx = appHtml.indexOf('<div')
+const headTags = firstDivIdx > 0 ? appHtml.slice(0, firstDivIdx).trim() : ''
+const bodyContent = firstDivIdx > 0 ? appHtml.slice(firstDivIdx) : appHtml
+
+let html = readFileSync(resolve(distDir, 'index.html'), 'utf-8')
+
+// Inject Helmet-managed head tags (title, canonical, OG, Twitter meta, etc.) into <head>
+if (headTags) {
+  html = html.replace('</head>', `    ${headTags}\n  </head>`)
+}
+
+// Inject only the page content (without duplicated head tags) into the root div
+html = html.replace('<div id="root"></div>', `<div id="root">${bodyContent}</div>`)
+
+writeFileSync(resolve(distDir, 'index.html'), html)
+
+// Clean up temporary SSR build
+rmSync(ssrDir, { recursive: true, force: true })
+
+console.log('✓ Pre-rendered /')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from 'react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { HelmetProvider } from 'react-helmet-async'
 import { ThemeProvider } from './contexts/ThemeContext'
 import ErrorBoundary from './components/ErrorBoundary'
 import LandingPage from './pages/LandingPage'
@@ -15,24 +16,26 @@ const Spinner = () => (
 
 export default function App() {
   return (
-    <ErrorBoundary>
-      <BrowserRouter>
-        <ThemeProvider>
-          <Routes>
-            {/* Landing page: no Firebase, no auth — renders immediately */}
-            <Route path="/" element={<LandingPage />} />
-            {/* All other routes: lazy-load Firebase + auth stack on demand */}
-            <Route
-              path="/*"
-              element={
-                <Suspense fallback={<Spinner />}>
-                  <PrivateSection />
-                </Suspense>
-              }
-            />
-          </Routes>
-        </ThemeProvider>
-      </BrowserRouter>
-    </ErrorBoundary>
+    <HelmetProvider>
+      <ErrorBoundary>
+        <BrowserRouter>
+          <ThemeProvider>
+            <Routes>
+              {/* Landing page: no Firebase, no auth — renders immediately */}
+              <Route path="/" element={<LandingPage />} />
+              {/* All other routes: lazy-load Firebase + auth stack on demand */}
+              <Route
+                path="/*"
+                element={
+                  <Suspense fallback={<Spinner />}>
+                    <PrivateSection />
+                  </Suspense>
+                }
+              />
+            </Routes>
+          </ThemeProvider>
+        </BrowserRouter>
+      </ErrorBoundary>
+    </HelmetProvider>
   )
 }

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -1,0 +1,22 @@
+import { renderToString } from 'react-dom/server'
+import { StaticRouter } from 'react-router-dom'
+import { HelmetProvider } from 'react-helmet-async'
+import type { HelmetServerState } from 'react-helmet-async'
+import { ThemeProvider } from './contexts/ThemeContext'
+import LandingPage from './pages/LandingPage'
+
+export function render(url: string): { appHtml: string; helmet: HelmetServerState | null | undefined } {
+  const helmetContext: { helmet?: HelmetServerState } = {}
+
+  const appHtml = renderToString(
+    <HelmetProvider context={helmetContext}>
+      <ThemeProvider>
+        <StaticRouter location={url}>
+          <LandingPage />
+        </StaticRouter>
+      </ThemeProvider>
+    </HelmetProvider>
+  )
+
+  return { appHtml, helmet: helmetContext.helmet }
+}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,7 +1,23 @@
 import { useEffect } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
+import { Helmet } from 'react-helmet-async'
 import { Sun, Moon, BarChart2, GripVertical, Calendar, MapPin, Sliders, Target, ImageIcon, Github, Code2, Eye, Layers, ExternalLink } from 'lucide-react'
 import { useTheme } from '../contexts/ThemeContext'
+
+const BASE_URL = 'https://flexpoll.app'
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'FlexPoll',
+  url: BASE_URL,
+  description:
+    'Create and share polls easily — Classic, Ranking, Schedule, Location, Priority, Image, and Custom HTML/CSS/JS poll types. Free forever, open source always.',
+  applicationCategory: 'SocialApplication',
+  operatingSystem: 'Web',
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  inLanguage: 'en',
+}
 
 // Check for a cached Firebase auth session without loading the Firebase SDK.
 // Firebase stores the current user in localStorage under a key starting with 'firebase:authUser:'.
@@ -227,6 +243,28 @@ export default function LandingPage() {
 
   return (
     <div className="min-h-screen bg-white dark:bg-gray-900 font-sans">
+      <Helmet>
+        <title>FlexPoll — The Place to Put a Poll</title>
+        <meta name="description" content="Create and share polls easily — Classic, Ranking, Schedule, Location, Priority, Image, and Custom HTML/CSS/JS poll types. Free forever, open source always." />
+        <link rel="canonical" href={`${BASE_URL}/`} />
+        <meta name="robots" content="index, follow" />
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content="FlexPoll" />
+        <meta property="og:title" content="FlexPoll — The Place to Put a Poll" />
+        <meta property="og:description" content="Create and share polls easily — Classic, Ranking, Schedule, Location, Priority, Image, and Custom HTML/CSS/JS poll types. Free forever, open source always." />
+        <meta property="og:url" content={`${BASE_URL}/`} />
+        <meta property="og:image" content={`${BASE_URL}/og-image.png`} />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta property="og:image:type" content="image/png" />
+        <meta property="og:image:alt" content="FlexPoll — Create and share every kind of poll" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="FlexPoll — The Place to Put a Poll" />
+        <meta name="twitter:description" content="Create and share polls easily — Classic, Ranking, Schedule, Location, Priority, Image, and Custom HTML/CSS/JS poll types. Free forever, open source always." />
+        <meta name="twitter:image" content={`${BASE_URL}/og-image.png`} />
+        <meta name="twitter:image:alt" content="FlexPoll — Create and share every kind of poll" />
+        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+      </Helmet>
 
       {/* Navbar */}
       <header className="sticky top-0 z-50 bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-800">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,10 +3,10 @@ import react from '@vitejs/plugin-react'
 import path from 'path'
 import { VitePWA } from 'vite-plugin-pwa'
 
-export default defineConfig({
+export default defineConfig(({ isSsrBuild }) => ({
   plugins: [
     react(),
-    VitePWA({
+    !isSsrBuild && VitePWA({
       registerType: 'autoUpdate',
       injectRegister: 'script-defer',
       includeAssets: ['favicon.svg', 'favicon.ico', 'apple-touch-icon-180x180.png', 'robots.txt'],
@@ -67,7 +67,7 @@ export default defineConfig({
         ],
       },
     }),
-  ],
+  ].filter(Boolean),
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
@@ -76,14 +76,16 @@ export default defineConfig({
   build: {
     rollupOptions: {
       output: {
-        manualChunks: {
-          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
-          'vendor-firebase': ['firebase/app', 'firebase/auth', 'firebase/firestore'],
-          'vendor-firebase-msg': ['firebase/messaging'],
-          'vendor-editor': ['@tiptap/react', '@tiptap/starter-kit'],
-          'vendor-leaflet': ['leaflet', 'react-leaflet'],
-        },
+        manualChunks: isSsrBuild
+          ? undefined
+          : {
+              'vendor-react': ['react', 'react-dom', 'react-router-dom'],
+              'vendor-firebase': ['firebase/app', 'firebase/auth', 'firebase/firestore'],
+              'vendor-firebase-msg': ['firebase/messaging'],
+              'vendor-editor': ['@tiptap/react', '@tiptap/starter-kit'],
+              'vendor-leaflet': ['leaflet', 'react-leaflet'],
+            },
       },
     },
   },
-})
+}))


### PR DESCRIPTION
vite-react-ssg is incompatible with React Router v7 (missing
react-router-dom/server.js subpath). Uses a custom two-step approach
instead:
- src/entry-server.tsx: SSR entry using renderToString + StaticRouter
  (available in RR v7) + react-helmet-async HelmetProvider
- scripts/prerender.js: post-build script that runs a Vite SSR build,
  extracts Helmet head tags from appHtml, injects them into <head>, and
  injects page body content into <div id="root">
- vite.config.ts: conditionally disables vite-plugin-pwa during SSR
  build (isSsrBuild) to prevent conflicts
- package.json: extends build script with SSR build + prerender step;
  adds react-helmet-async dependency

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QzBCntpbyEHenMmbMEQjtM