### PR TITLE
feat: add llms.txt for LLM crawler guidance

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,15 @@
+# FlexPoll
+
+> FlexPoll is a free, open-source polling web app. Create and share Standard, Schedule, Location, Ranking, Priority, Image, and Custom HTML/CSS/JS polls, then collect votes and view results in real time.
+
+FlexPoll is built with React, TypeScript, and Firebase. Polls can be shared via link or QR code, results update live, and the app is installable as a PWA.
+
+## Docs
+
+- [Homepage](https://flexpoll.app/): Overview of FlexPoll and its poll types
+- [Explore](https://flexpoll.app/explore): Browse public polls from other users
+- [Create a poll](https://flexpoll.app/create): Start creating a new poll
+
+## Optional
+
+- [GitHub repository](https://github.com/gnadi/0815poll): Source code, issues, and contributions


### PR DESCRIPTION
Follows the llmstxt.org spec (H1 header + linked docs section) so tools
that check for it stop flagging a missing/malformed file.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015bHBDv1ewsf9fuPYSY8BDU